### PR TITLE
Minor debug for Call Node event and Character event update pos

### DIFF
--- a/Converter/settings_converter.gd
+++ b/Converter/settings_converter.gd
@@ -469,7 +469,7 @@ func convertTimelines():
 
 													if event['position'][i] == true:
 														positionCheck = true
-														eventLine += str(i.to_int())
+														eventLine += " " + str(i.to_int())
 
 											if !positionCheck:
 												eventLine += " 0"
@@ -764,7 +764,7 @@ func convertTimelines():
 							file.store_line("# Converted Call Node")
 							eventLine += "do " + event['call_node']['target_node_path'] + "."
 							eventLine += event['call_node']['method_name']
-							eventLine += ".("
+							eventLine += "("
 							var argNum:int = 0
 							for arg in event['call_node']['arguments']:
 								if argNum > 0:


### PR DESCRIPTION
- Fixes Call Node having an extra period before parentheses
- Fixes Character Event update position needing space before inserting position int arg

tested and working on 1.5.1 to 2.0-Alpha 13 (Godot 4.2+)